### PR TITLE
Upgrade linux runner image to Ubuntu 24.04 LTS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           24,    # Current Java LTS & minimum supported by Minecraft
         ]
         # and run on both Linux and Windows
-        os: [ubuntu-20.04, windows-2022]
+        os: [ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository


### PR DESCRIPTION
The Ubuntu 20.04 LTS image was deprecated on 2025-02-01 and removed on 2025-04-15.
Announced in https://github.com/actions/runner-images/issues/11101 (currently down, available via the [Internet Archive](https://web.archive.org/web/20250830081644/https://github.com/actions/runner-images/issues/11101).