### PR TITLE
feat: Upgrade gradle to 9.1.0 and fix CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,27 +12,26 @@ jobs:
       matrix:
         # Use these Java versions
         java: [
-          24,    # Current Java LTS & minimum supported by Minecraft
+          21,    # Previous Java LTS & minimum supported by Minecraft
+          25,    # Current Java LTS
         ]
         # and run on both Linux and Windows
         os: [ubuntu-24.04, windows-2022]
     runs-on: ${{ matrix.os }}
     steps:
       - name: checkout repository
-        uses: actions/checkout@v2
-      - name: validate gradle wrapper
-        uses: gradle/wrapper-validation-action@v1
-      - name: setup jdk ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/checkout@v5
+      - name: setup Java ${{ matrix.java }}
+        uses: actions/setup-java@v2
         with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java }}
-      - name: make gradle wrapper executable
-        if: ${{ runner.os != 'Windows' }}
-        run: chmod +x ./gradlew
+      - name: setup Gradle
+        uses: gradle/actions/setup-gradle@v4
       - name: build
         run: ./gradlew build
       - name: capture build artifacts
-        if: ${{ runner.os == 'Linux' && matrix.java == '24' }} # Only upload artifacts built from latest java on one OS
+        if: ${{ runner.os == 'Linux' && matrix.java == '25' }} # Only upload artifacts built from latest java on one OS
         uses: actions/upload-artifact@v4
         with:
           name: Artifacts

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,6 @@ plugins {
 	id 'maven-publish'
 }
 
-sourceCompatibility = JavaVersion.VERSION_17
-targetCompatibility = JavaVersion.VERSION_17
-
 archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
@@ -59,6 +56,8 @@ tasks.withType(JavaCompile).configureEach {
 }
 
 java {
+	sourceCompatibility = JavaVersion.VERSION_17
+	targetCompatibility = JavaVersion.VERSION_17
 	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
 	// if it is present.
 	// If you remove this line, sources will not be generated.

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ repositories {
 	// Loom adds the essential maven repositories to download Minecraft and libraries from automatically.
 	// See https://docs.gradle.org/current/userguide/declaring_repositories.html
 	// for more information about repositories.
-	maven { url 'https://jitpack.io' }
+	maven { url = 'https://jitpack.io' }
 
 	// Needed to retrieve Cloth Config Lite for development environments.
 	maven {

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,12 @@ plugins {
 	id 'maven-publish'
 }
 
-archivesBaseName = project.archives_base_name
 version = project.mod_version
 group = project.maven_group
+
+base {
+	archivesName = project.archives_base_name
+}
 
 repositories {
 	// Add repositories to retrieve artifacts from in here.
@@ -66,7 +69,7 @@ java {
 
 jar {
 	from("LICENSE") {
-		rename { "${it}_${project.archivesBaseName}"}
+		rename { "${it}_${project.archives_base_name}"}
 	}
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
I spent way too much time on this since I'll probably never use it, but I couldn't let you run some outdated versions and a failing pipeline!

- Upgraded Gradle to 9.1.0 form 8.14.3 and make the necessary changes to `build.gradle`
- Adapted CI pipeline to test on JDK 21 (previous LTS & Minecraft minimum supported version) and 25(current LTS)
- Upgraded to `actions/checkout@v5` from `actions/checkout@v2`
- Upgraded tp `actions/setup-java@v2` from `actions/setup-java@v1` and using Temurin JDK
- Switched from `gradle/wrapper-validation-action@v1` to `gradle/actions/setup-gradle@v4`